### PR TITLE
Allow users to actually modify iteration count

### DIFF
--- a/LambdaMicrobenchmarking/Run.cs
+++ b/LambdaMicrobenchmarking/Run.cs
@@ -14,6 +14,7 @@ namespace LambdaMicrobenchmarking
         private double[] measurements;
         private Func<T> func;
         internal static int iterations = 10;
+        internal static int warmups = 3;
 
         public Run(Tuple<String, Func<T>> runTuple)
         {
@@ -98,7 +99,8 @@ namespace LambdaMicrobenchmarking
             var sw = new Stopwatch();
 
             // First invocation to compile method.
-            Compiler.ConsumeValue(func());
+            for (int i = 0; i < warmups; i++)
+                Compiler.ConsumeValue(func());
 
             for (int i = 0; i < GetN(); i++)
             {

--- a/LambdaMicrobenchmarking/Run.cs
+++ b/LambdaMicrobenchmarking/Run.cs
@@ -13,7 +13,7 @@ namespace LambdaMicrobenchmarking
         private string title;
         private double[] measurements;
         private Func<T> func;
-        private static int iterations = 10;
+        internal static int iterations = 10;
 
         public Run(Tuple<String, Func<T>> runTuple)
         {

--- a/LambdaMicrobenchmarking/Script.cs
+++ b/LambdaMicrobenchmarking/Script.cs
@@ -26,7 +26,11 @@ namespace LambdaMicrobenchmarking
             set { Run<T>.iterations = value; }
         }
 
-        static public int WarmupIterations { get; set; }
+        static public int WarmupIterations
+        {
+            get { return Run<T>.warmups; }
+            set { Run<T>.warmups = value; }
+        }
 
         private List<Tuple<String, Func<T>>> actions { get; set; }
 

--- a/LambdaMicrobenchmarking/Script.cs
+++ b/LambdaMicrobenchmarking/Script.cs
@@ -20,7 +20,12 @@ namespace LambdaMicrobenchmarking
     }
     public class Script<T>
     {
-        static public int Iterations { get; set; }
+        static public int Iterations
+        {
+            get { return Run<T>.iterations; }
+            set { Run<T>.iterations = value; }
+        }
+
         static public int WarmupIterations { get; set; }
 
         private List<Tuple<String, Func<T>>> actions { get; set; }


### PR DESCRIPTION
Hi, I would like to use your library for a project of mine, but I noticed that there currently is no way to actually change the iteration count and the number of warm-up iterations.

So I have made a small change that delegates setting the properties for ```Iterations``` and ```WarmupIterations``` on ```Script``` to static fields on ```Run```. I tried to keep it as simple as possible and I hope you can accept my changes :)

Cheers,
Florian